### PR TITLE
feat: Add LinkedIn profile fetching support

### DIFF
--- a/.cursor/rules/collaboration-rules.mdc
+++ b/.cursor/rules/collaboration-rules.mdc
@@ -1,0 +1,30 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+# Collaboration Rules
+
+## Planning and Confirmation Rule
+
+**Before implementing any code changes, features, or modifications:**
+
+1. **Create a Plan**: Always develop a clear, detailed plan that outlines:
+   - What changes will be made
+   - Which files will be modified or created
+   - The approach and methodology
+   - Expected outcomes and impacts
+
+2. **Confirm with User**: Present the plan to the user and wait for explicit confirmation before:
+   - Making any file modifications
+   - Creating new files
+   - Running commands that modify the codebase
+   - Implementing any suggested changes
+
+3. **Get Approval**: Only proceed with implementation after receiving clear approval from the user.
+
+4. **No Assumptions**: Never assume the user wants changes implemented immediately, even if they seem obvious or beneficial.
+
+**Exception**: Read-only operations (viewing files, searching, analyzing) do not require prior confirmation.
+
+This rule ensures we maintain collaborative control over the codebase and prevents unwanted changes.

--- a/.cursor/rules/tee-types_update_plan.mdc
+++ b/.cursor/rules/tee-types_update_plan.mdc
@@ -1,0 +1,48 @@
+---
+description: 
+globs: 
+alwaysApply: false
+---
+# tee-types: LinkedIn Data Structures Extension
+
+## Overview
+This plan details the required changes for the `github.com/masa-finance/tee-types` repository. These changes are a prerequisite for integrating the new LinkedIn profile fetching functionality into the `tee-worker`. The goal is to extend the existing data structures to support both profile search and full profile fetching jobs.
+
+## ⚠️ CRITICAL REQUIREMENTS
+- **BACKWARD COMPATIBILITY**: The changes must not break existing `tee-worker` functionality that relies on `searchbyquery`.
+- **CONSISTENCY**: The new data structures should align with the output of the `linkedin-scraper` SDK (`v1.0.0`).
+- **CLARITY**: Use clear and descriptive naming for new structs and fields.
+
+## Implementation Steps
+
+### Phase 1: Argument Structure Update
+
+#### Step 1.1: Extend and Rename Job Arguments
+**Objective**: Create a unified argument struct that supports both search and profile fetching.
+**Files**: `args/linkedin.go`
+**Action**:
+- Rename the existing `LinkedInSearchArguments` struct to `LinkedInArguments`. This provides a more generic name for future extensions.
+- Add a new field `PublicIdentifier string `json:"public_identifier,omitempty"` to the renamed `LinkedInArguments` struct. This will be used to specify the target profile for fetching.
+**Verification**: The new `LinkedInArguments` struct contains fields for both search (`Query`, `MaxResults`, etc.) and profile fetching (`PublicIdentifier`).
+**Commit**: `feat(args): extend and rename linkedin arguments for profile fetching`
+
+### Phase 2: Result Structure Extension
+
+#### Step 2.1: Define Comprehensive Profile Result
+**Objective**: Create a new struct to hold the rich data from a full profile fetch.
+**Files**: `types/linkedin.go`
+**Action**:
+- Create a new struct `LinkedInFullProfileResult`.
+- This struct should include fields for all the data provided by the scraper's `GetProfile` method, such as:
+  - `PublicIdentifier`, `URN`, `FullName`, `Headline`, `Location`, `Summary`
+  - Slices for `[]Experience`, `[]Education`, `[]Skill`
+  - `ProfilePictureURL`
+- Define helper structs for `Experience`, `Education`, and `Skill` with relevant fields (e.g., `Title`, `CompanyName` for experience; `SchoolName`, `DegreeName` for education).
+**Verification**: The `LinkedInFullProfileResult` and its nested structs are defined and compile correctly. The structure matches the expected output from the `linkedin-scraper`.
+**Commit**: `feat(types): add LinkedInFullProfileResult for detailed profiles`
+
+## Success Criteria
+- ✅ `args/linkedin.go` contains the updated `LinkedInArguments` struct.
+- ✅ `types/linkedin.go` contains the new `LinkedInFullProfileResult` and its associated substructures.
+- ✅ The changes are non-breaking for code that uses the old `LinkedInSearchArguments` (after a name update).
+- ✅ The new structures are ready to be consumed by the `tee-worker`.

--- a/args/linkedin.go
+++ b/args/linkedin.go
@@ -1,10 +1,15 @@
 package args
 
-// LinkedInSearchArguments defines args for LinkedIn searches
-type LinkedInSearchArguments struct {
-	QueryType      string   `json:"type"`                       // "searchbyquery", "getprofile"
-	Query          string   `json:"query"`                      // Keywords for search or username for profile
-	NetworkFilters []string `json:"network_filters,omitempty"` // ["F", "S", "O"] - First, Second, Other (default: all)
-	MaxResults     int      `json:"max_results"`                // Maximum number of results to return
-	Start          int      `json:"start"`                      // Pagination start offset
+// LinkedInArguments defines args for LinkedIn operations
+type LinkedInArguments struct {
+	QueryType        string   `json:"type"`  // "searchbyquery", "getprofile"
+	Query            string   `json:"query"` // Keywords for search or username for profile
+	PublicIdentifier string   `json:"public_identifier,omitempty"`
+	NetworkFilters   []string `json:"network_filters,omitempty"` // ["F", "S", "O"] - First, Second, Other (default: all)
+	MaxResults       int      `json:"max_results"`               // Maximum number of results to return
+	Start            int      `json:"start"`                     // Pagination start offset
 }
+
+// LinkedInSearchArguments is an alias for LinkedInArguments for backward compatibility.
+// Deprecated: use LinkedInArguments instead.
+type LinkedInSearchArguments = LinkedInArguments

--- a/types/linkedin.go
+++ b/types/linkedin.go
@@ -11,3 +11,42 @@ type LinkedInProfileResult struct {
 	ProfileURL       string `json:"profile_url"`       // Full LinkedIn profile URL
 	Degree           string `json:"degree,omitempty"`  // Connection degree (1st, 2nd, etc.)
 }
+
+// Experience defines the structure for a single entry in a user's work experience
+type Experience struct {
+	Title       string `json:"title"`
+	CompanyName string `json:"company_name"`
+	Location    string `json:"location,omitempty"`
+	StartDate   string `json:"start_date,omitempty"`
+	EndDate     string `json:"end_date,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+// Education defines the structure for a single entry in a user's education history
+type Education struct {
+	SchoolName   string `json:"school_name"`
+	DegreeName   string `json:"degree_name,omitempty"`
+	FieldOfStudy string `json:"field_of_study,omitempty"`
+	StartDate    string `json:"start_date,omitempty"`
+	EndDate      string `json:"end_date,omitempty"`
+	Description  string `json:"description,omitempty"`
+}
+
+// Skill defines the structure for a single skill entry
+type Skill struct {
+	Name string `json:"name"`
+}
+
+// LinkedInFullProfileResult defines the structure for a detailed LinkedIn profile
+type LinkedInFullProfileResult struct {
+	PublicIdentifier  string       `json:"public_identifier"`
+	URN               string       `json:"urn"`
+	FullName          string       `json:"full_name"`
+	Headline          string       `json:"headline"`
+	Location          string       `json:"location"`
+	Summary           string       `json:"summary,omitempty"`
+	ProfilePictureURL string       `json:"profile_picture_url,omitempty"`
+	Experiences       []Experience `json:"experiences,omitempty"`
+	Education         []Education  `json:"education,omitempty"`
+	Skills            []Skill      `json:"skills,omitempty"`
+}


### PR DESCRIPTION
## Overview
This PR extends the tee-types repository to support LinkedIn profile fetching functionality, which is a prerequisite for integrating the new LinkedIn profile fetching functionality into the tee-worker.

## Changes Made

### Phase 1: Argument Structure Update
- **Renamed**  to  for broader scope
- **Added**  field to support individual profile fetching
- **Maintained** backward compatibility with deprecated type alias
- **Preserved** existing search functionality with omitempty tag

### Phase 2: Result Structure Extension
- **Added**  struct for comprehensive profile data
- **Created** helper structs: , , and 
- **Supports** rich profile information including:
  - Basic profile data (name, headline, location, summary)
  - Profile picture URL
  - Work experience history with dates and descriptions
  - Education background with degrees and fields of study
  - Skills list
- **Aligned** structures with linkedin-scraper SDK v1.0.0 output

## Backward Compatibility
✅ **Non-breaking changes** - existing code using  will continue to work
✅ **Deprecation warnings** - linter will show deprecation messages for old type usage
✅ **Smooth migration path** - developers can migrate to  at their convenience

## Testing
- [x] Code compiles successfully
- [x] Backward compatibility maintained
- [x] New structures ready for tee-worker integration

## Next Steps
After merging, this will enable the tee-worker to:
1. Continue using existing search functionality
2. Add new profile fetching capabilities
3. Handle rich profile data from the linkedin-scraper SDK