### PR TITLE
fix: remove searchbyfullarchive subtype from cred based capabilities

### DIFF
--- a/types/jobs.go
+++ b/types/jobs.go
@@ -65,7 +65,7 @@ var (
 
 	// TwitterAllCaps are all Twitter capabilities available with credential-based auth
 	TwitterAllCaps = []Capability{
-		CapSearchByQuery, CapSearchByFullArchive, CapSearchByProfile,
+		CapSearchByQuery, CapSearchByProfile,
 		CapGetById, CapGetReplies, CapGetRetweeters, CapGetTweets, CapGetMedia,
 		CapGetHomeTweets, CapGetForYouTweets, CapGetProfileById,
 		CapGetTrends, CapGetFollowing, CapGetFollowers, CapGetSpace,


### PR DESCRIPTION
Removes "CapSearchByFullArchive" from default credential capabilities