### PR TITLE
fix: twitter-guard-and-job-definitions

### DIFF
--- a/args/twitter.go
+++ b/args/twitter.go
@@ -64,7 +64,7 @@ func (t *TwitterSearchArguments) Validate() error {
 		return fmt.Errorf("%w, got: %d", ErrTwitterMaxResultsNegative, t.MaxResults)
 	}
 	if t.MaxResults > TwitterMaxResults {
-		return fmt.Errorf("%w, got: %d", ErrTwitterMaxResultsTooLarge, t.Count)
+		return fmt.Errorf("%w, got: %d", ErrTwitterMaxResultsTooLarge, t.MaxResults)
 	}
 
 	return nil

--- a/args/twitter.go
+++ b/args/twitter.go
@@ -2,10 +2,17 @@ package args
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
 	teetypes "github.com/masa-finance/tee-types/types"
+)
+
+var (
+	ErrTwitterCountNegative      = errors.New("count must be non-negative")
+	ErrTwitterCountTooLarge      = errors.New("count must be less than or equal to 1000")
+	ErrTwitterMaxResultsNegative = errors.New("max_results must be non-negative")
 )
 
 // TwitterSearchArguments defines args for Twitter searches
@@ -44,11 +51,15 @@ func (t *TwitterSearchArguments) Validate() error {
 	// note, query is not required for all capabilities
 
 	if t.Count < 0 {
-		return fmt.Errorf("count must be non-negative, got: %d", t.Count)
+		return fmt.Errorf("%w, got: %d", ErrTwitterCountNegative, t.Count)
+	}
+
+	if t.Count > 1000 {
+		return fmt.Errorf("%w, got: %d", ErrTwitterCountTooLarge, t.Count)
 	}
 
 	if t.MaxResults < 0 {
-		return fmt.Errorf("max_results must be non-negative, got: %d", t.MaxResults)
+		return fmt.Errorf("%w, got: %d", ErrTwitterMaxResultsNegative, t.MaxResults)
 	}
 
 	return nil

--- a/args/twitter.go
+++ b/args/twitter.go
@@ -12,6 +12,7 @@ import (
 var (
 	ErrTwitterCountNegative      = errors.New("count must be non-negative")
 	ErrTwitterCountTooLarge      = errors.New("count must be less than or equal to 1000")
+	ErrTwitterMaxResultsTooLarge = errors.New("max_results must be less than or equal to 1000")
 	ErrTwitterMaxResultsNegative = errors.New("max_results must be non-negative")
 )
 
@@ -49,17 +50,17 @@ func (t *TwitterSearchArguments) UnmarshalJSON(data []byte) error {
 // Validate validates the Twitter arguments (general validation)
 func (t *TwitterSearchArguments) Validate() error {
 	// note, query is not required for all capabilities
-
 	if t.Count < 0 {
 		return fmt.Errorf("%w, got: %d", ErrTwitterCountNegative, t.Count)
 	}
-
 	if t.Count > 1000 {
 		return fmt.Errorf("%w, got: %d", ErrTwitterCountTooLarge, t.Count)
 	}
-
 	if t.MaxResults < 0 {
 		return fmt.Errorf("%w, got: %d", ErrTwitterMaxResultsNegative, t.MaxResults)
+	}
+	if t.MaxResults > 1000 {
+		return fmt.Errorf("%w, got: %d", ErrTwitterMaxResultsTooLarge, t.Count)
 	}
 
 	return nil

--- a/args/twitter.go
+++ b/args/twitter.go
@@ -16,6 +16,10 @@ var (
 	ErrTwitterMaxResultsNegative = errors.New("max_results must be non-negative")
 )
 
+const (
+	TwitterMaxResults = 1000
+)
+
 // TwitterSearchArguments defines args for Twitter searches
 type TwitterSearchArguments struct {
 	QueryType  string `json:"type"`  // Optional, type of search
@@ -53,13 +57,13 @@ func (t *TwitterSearchArguments) Validate() error {
 	if t.Count < 0 {
 		return fmt.Errorf("%w, got: %d", ErrTwitterCountNegative, t.Count)
 	}
-	if t.Count > 1000 {
+	if t.Count > TwitterMaxResults {
 		return fmt.Errorf("%w, got: %d", ErrTwitterCountTooLarge, t.Count)
 	}
 	if t.MaxResults < 0 {
 		return fmt.Errorf("%w, got: %d", ErrTwitterMaxResultsNegative, t.MaxResults)
 	}
-	if t.MaxResults > 1000 {
+	if t.MaxResults > TwitterMaxResults {
 		return fmt.Errorf("%w, got: %d", ErrTwitterMaxResultsTooLarge, t.Count)
 	}
 

--- a/types/jobs.go
+++ b/types/jobs.go
@@ -13,12 +13,12 @@ type JobType string
 
 type JobArguments map[string]interface{}
 
-func (ja JobArguments) Unmarshal(i interface{}) error {
-	dat, err := json.Marshal(ja)
+func (j JobArguments) Unmarshal(i interface{}) error {
+	d, err := json.Marshal(j)
 	if err != nil {
 		return err
 	}
-	return json.Unmarshal(dat, i)
+	return json.Unmarshal(d, i)
 }
 
 type Job struct {

--- a/types/jobs.go
+++ b/types/jobs.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/json"
 	"fmt"
 	"slices"
 	"time"
@@ -11,6 +12,14 @@ import (
 type JobType string
 
 type JobArguments map[string]interface{}
+
+func (ja JobArguments) Unmarshal(i interface{}) error {
+	dat, err := json.Marshal(ja)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(dat, i)
+}
 
 type Job struct {
 	Type         JobType       `json:"type"`

--- a/types/jobs.go
+++ b/types/jobs.go
@@ -3,11 +3,25 @@ package types
 import (
 	"fmt"
 	"slices"
+	"time"
 
 	"github.com/masa-finance/tee-types/pkg/util"
 )
 
 type JobType string
+
+type JobArguments map[string]interface{}
+
+type Job struct {
+	Type         JobType       `json:"type"`
+	Arguments    JobArguments  `json:"arguments"`
+	UUID         string        `json:"-"`
+	Nonce        string        `json:"quote"`
+	WorkerID     string        `json:"worker_id"`
+	TargetWorker string        `json:"target_worker"`
+	Timeout      time.Duration `json:"timeout"`
+}
+
 type Capability string
 type WorkerCapabilities map[JobType][]Capability
 


### PR DESCRIPTION
### What
- Brings generic job types into tee types to unblock acceptance tests from importing ego related packages
- Guards twitter followers arguments to 1000 count as to prevent further exploits

### Why
- Acceptance tests need an ego enclave as they rely on "github.com/masa-finance/tee-indexer/internal/types".  The offending package is in job.go - which imports "github.com/masa-finance/tee-worker/api/types".  We can simply move the few types/structs in that package to tee types to prevent the ego issue
- We were getting slightly exploited on the `twitter-apify` type with users requesting 100k followers (costing the miners $15 a turn).  This prevents that, bringing the count to `1000`, a tested and supported amount via the indexer / NATS