### PR TITLE
chore(ci): upgrade checkout to v5

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
       run: sudo snap install golangci-lint --classic
 
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
 
     - name: Setup Golang with cache
       uses: magnetikonline/action-golang-cache@v5
@@ -42,7 +42,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
 
     - name: Setup Golang with cache
       uses: magnetikonline/action-golang-cache@v5
@@ -58,7 +58,7 @@ jobs:
 
       steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v5
 
       - name: Verify that merging is OK
         run: |


### PR DESCRIPTION
Maintenance update to actions/checkout@v5 to align with the current runner stack (Node 24); nothing else modified.
Release notes: https://github.com/actions/checkout/releases/tag/v5.0.0